### PR TITLE
Add synthetic dNBR visualization example

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,19 @@ This repository now includes a lightweight Python engine for accessing Sentinel-
 
 3. Open `artifacts/dnbr_overlay.html` in your browser to view the dNBR overlay on OpenStreetMap.
 
+### Visualize an existing NBR / dNBR array
+You only need two pieces of information to render an overlay:
+- A 2D NumPy array containing NBR or dNBR values (typically in the range [-1, 1]).
+- The bounding box for the array in WGS84 coordinates as `(min_lon, min_lat, max_lon, max_lat)`.
+
+The helper `dragonfly.viz.raster_overlay` handles normalization, colorizing with the USGS burn severity colormap, and creating a Folium map. For a quick, offline example that uses a synthetic dNBR array, run:
+
+```bash
+python examples/visualize_dnbr_overlay.py
+```
+
+The script saves `./artifacts/synthetic_dnbr_overlay.html`, which you can open in a browser to inspect the overlay.
+
 ## Key Modules
 - `dragonfly.data_access.SentinelStacConnector` – STAC search and band download
 - `dragonfly.processing.calculate_nbr` / `calculate_dnbr` – spectral indices

--- a/examples/visualize_dnbr_overlay.py
+++ b/examples/visualize_dnbr_overlay.py
@@ -1,0 +1,58 @@
+"""Generate a Folium map from an in-memory dNBR array.
+
+This example builds a synthetic dNBR raster so you can see how the
+visualization pipeline works without downloading Sentinel-2 data.
+"""
+from __future__ import annotations
+
+from pathlib import Path
+
+import numpy as np
+
+from dragonfly.viz import raster_overlay
+
+
+def synthetic_dnbr(size: int = 256) -> np.ndarray:
+    """Create a smooth dNBR-like surface for testing visualization.
+
+    The array values are clipped to the expected [-1, 1] range for dNBR,
+    with a bright circular "burn" in the center and a small recovering
+    patch to the west. The shape is square to simplify working with folium's
+    image overlay helper.
+    """
+
+    y, x = np.mgrid[-1:1 : size * 1j, -1:1 : size * 1j]
+
+    # Gentle background variation
+    base = 0.05 * np.sin(3 * np.pi * x) * np.cos(2 * np.pi * y)
+
+    # Burned area with high positive dNBR values near the center
+    burn = 0.7 * np.exp(-6 * (x**2 + y**2))
+
+    # A recovering / unburned patch to illustrate negative and low values
+    recovery = -0.25 * np.exp(-10 * ((x + 0.5) ** 2 + (y + 0.2) ** 2))
+
+    dnbr = base + burn + recovery
+    return np.clip(dnbr, -1.0, 1.0)
+
+
+def main() -> None:
+    # Define the bounding box (min_lon, min_lat, max_lon, max_lat)
+    bounds = (12.25, 45.45, 12.35, 45.55)
+
+    # Create a synthetic dNBR raster
+    dnbr_array = synthetic_dnbr(size=300)
+
+    # Render an interactive folium map using the built-in USGS colormap
+    fmap = raster_overlay(dnbr_array, bounds=bounds, name="Synthetic dNBR")
+
+    artifacts_dir = Path("./artifacts")
+    artifacts_dir.mkdir(exist_ok=True)
+    output_html = artifacts_dir / "synthetic_dnbr_overlay.html"
+
+    fmap.save(output_html)
+    print(f"Saved overlay to {output_html}")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
### **User description**
## Summary
- explain the minimal inputs required to render an NBR/dNBR overlay
- add an offline example script that generates a synthetic dNBR raster and saves a Folium map

## Testing
- PYTHONPATH=./src python examples/visualize_dnbr_overlay.py


------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_6921aea838f08321bc4e12c0c15e09a5)


___

### **PR Type**
Enhancement, Documentation


___

### **Description**
- Add synthetic dNBR visualization example script for offline testing

- Demonstrate minimal inputs required for NBR/dNBR overlay rendering

- Document `raster_overlay` helper usage with bounding box and array inputs

- Create reusable synthetic dNBR generator with burn and recovery patterns


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Synthetic dNBR Array"] -- "bounds + array" --> B["raster_overlay helper"]
  B -- "normalization & colormap" --> C["Folium Map"]
  C -- "save HTML" --> D["Interactive Visualization"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>visualize_dnbr_overlay.py</strong><dd><code>Synthetic dNBR visualization example script</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

examples/visualize_dnbr_overlay.py

<ul><li>Create new example script demonstrating offline dNBR visualization<br> <li> Implement <code>synthetic_dnbr()</code> function generating smooth test raster with <br>burn and recovery patterns<br> <li> Define <code>main()</code> function showing minimal required inputs: 2D array and <br>WGS84 bounding box<br> <li> Save generated Folium map to <code>artifacts/synthetic_dnbr_overlay.html</code></ul>


</details>


  </td>
  <td><a href="https://github.com/indietonne2/Dragonfly/pull/6/files#diff-df1871e56c6ded14181624d3bd0434ed174e77b5221448d004a1342f05a6ac48">+58/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>README.md</strong><dd><code>Document NBR/dNBR array visualization usage</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

README.md

<ul><li>Add new section documenting how to visualize existing NBR/dNBR arrays<br> <li> Explain minimal requirements: 2D NumPy array and WGS84 bounding box <br>coordinates<br> <li> Document <code>dragonfly.viz.raster_overlay</code> helper functionality and <br>features<br> <li> Provide quick-start command to run synthetic dNBR example offline</ul>


</details>


  </td>
  <td><a href="https://github.com/indietonne2/Dragonfly/pull/6/files#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5">+13/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

